### PR TITLE
feat: 구글 스프레드 시트 직무별 퀘스트 동기화(#5)

### DIFF
--- a/src/main/java/pepperstone/backend/common/repository/JobQuestProgressRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/JobQuestProgressRepository.java
@@ -3,7 +3,12 @@ package pepperstone.backend.common.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import pepperstone.backend.common.entity.JobQuestProgressEntity;
+import pepperstone.backend.common.entity.JobQuestsEntity;
+import pepperstone.backend.common.entity.UserEntity;
+
+import java.util.List;
 
 @Repository
 public interface JobQuestProgressRepository extends JpaRepository<JobQuestProgressEntity, Long> {
+    List<JobQuestProgressEntity> findByJobQuestAndUsers(JobQuestsEntity jobQuest, UserEntity user);
 }

--- a/src/main/java/pepperstone/backend/common/repository/JobQuestProgressRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/JobQuestProgressRepository.java
@@ -1,0 +1,9 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.JobQuestProgressEntity;
+
+@Repository
+public interface JobQuestProgressRepository extends JpaRepository<JobQuestProgressEntity, Long> {
+}

--- a/src/main/java/pepperstone/backend/common/repository/JobQuestRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/JobQuestRepository.java
@@ -1,0 +1,12 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.JobQuestsEntity;
+
+import java.util.Optional;
+
+@Repository
+public interface JobQuestRepository extends JpaRepository<JobQuestsEntity, Long> {
+    Optional<JobQuestsEntity> findByDepartmentAndJobGroup(String department, String jobGroup);
+}

--- a/src/main/java/pepperstone/backend/common/repository/UserRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.UserEntity;
+
+import java.util.List;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+    List<UserEntity> findByJobGroupJobNameAndJobGroupCenterGroupCenterName(String jobName, String centerName);
+}

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -65,7 +65,7 @@ public class SyncController {
             // 잘못된 요청에 대한 처리
             response.put("code", 400);
             response.put("message", e.getMessage());
-            response.put("data", Collections.emptyList());
+            response.put("data", type);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
 
         } catch (Exception e) {

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -30,9 +30,10 @@ public class SyncController {
             List<Map<String, Object>> values = new ArrayList<>();
             switch (type) {
                 case "all" -> {
-                    values = jobSyncService.sync(SPREADSHEET_ID);
+                    //values = jobSyncService.sync(SPREADSHEET_ID);
+                    jobSyncService.sync(SPREADSHEET_ID);
                 }
-                case "job" -> values = jobSyncService.sync(SPREADSHEET_ID);
+                case "job" -> jobSyncService.sync(SPREADSHEET_ID);
                 case "leader" -> {
                 }
                 case "project" -> {

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -1,0 +1,49 @@
+package pepperstone.backend.sync.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import pepperstone.backend.sync.service.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/sync")
+@RequiredArgsConstructor
+public class SyncController {
+
+    private final JobSyncService jobSyncService;
+    private final LeaderSyncService leaderSyncService;
+    private final ProjectSyncService projectSyncService;
+    private final EvaluationSyncService evaluationSyncService;
+    private static final String SPREADSHEET_ID = "1knh-jdu_Zyn8dsqE7Owds6TaVlGn4XZsTQ2U6ratgFs"; // 스프레스 시트id를 복사해둔곳을 여기에 저장
+
+    @GetMapping("/googlesheet")
+    public ResponseEntity<List<Map<String, Object>>> readSheet(@RequestParam String type) {
+        try {
+            List<Map<String, Object>> values = new ArrayList<>();
+            switch (type) {
+                case "all" -> {
+                    values = jobSyncService.sync(SPREADSHEET_ID);
+                }
+                case "job" -> values = jobSyncService.sync(SPREADSHEET_ID);
+                case "leader" -> {
+                }
+                case "project" -> {
+                }
+                case "evaluation" -> {
+                }
+            }
+            return ResponseEntity.ok(values);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body(Collections.emptyList());
+        }
+    }
+}

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -1,6 +1,7 @@
 package pepperstone.backend.sync.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,10 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pepperstone.backend.sync.service.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @RestController
 @RequestMapping("/sync")
@@ -25,26 +23,57 @@ public class SyncController {
     private static final String SPREADSHEET_ID = "1knh-jdu_Zyn8dsqE7Owds6TaVlGn4XZsTQ2U6ratgFs"; // 스프레스 시트id를 복사해둔곳을 여기에 저장
 
     @GetMapping("/googlesheet")
-    public ResponseEntity<List<Map<String, Object>>> readSheet(@RequestParam String type) {
+    public ResponseEntity<Map<String, Object>> readSheet(@RequestParam String type) {
+        Map<String, Object> response = new HashMap<>();
         try {
-            List<Map<String, Object>> values = new ArrayList<>();
+            String message;
             switch (type) {
                 case "all" -> {
-                    //values = jobSyncService.sync(SPREADSHEET_ID);
                     jobSyncService.sync(SPREADSHEET_ID);
+                    //leaderSyncService.sync(SPREADSHEET_ID);
+                    //projectSyncService.sync(SPREADSHEET_ID);
+                    //evaluationSyncService.sync(SPREADSHEET_ID);
+                    message = "전체 동기화가 완료되었습니다.";
                 }
-                case "job" -> jobSyncService.sync(SPREADSHEET_ID);
+                case "job" -> {
+                    jobSyncService.sync(SPREADSHEET_ID);
+                    message = "직무별 퀘스트 동기화가 완료되었습니다.";
+                }
                 case "leader" -> {
+                    //leaderSyncService.sync(SPREADSHEET_ID);
+                    message = "리더부여 퀘스트 동기화가 완료되었습니다.";
                 }
                 case "project" -> {
+                    //projectSyncService.sync(SPREADSHEET_ID);
+                    message = "전사 프로젝트 동기화가 완료되었습니다.";
                 }
                 case "evaluation" -> {
+                    //evaluationSyncService.sync(SPREADSHEET_ID);
+                    message = "인사 평가 동기화가 완료되었습니다.";
                 }
+                default -> throw new IllegalArgumentException("Invalid sync type: " + type);
             }
-            return ResponseEntity.ok(values);
+
+            // 성공 응답 형식 반환
+            response.put("code", 200);
+            response.put("message", message);
+            response.put("data", type);
+
+            return ResponseEntity.ok(response);
+
+        } catch (IllegalArgumentException e) {
+            // 잘못된 요청에 대한 처리
+            response.put("code", 400);
+            response.put("message", e.getMessage());
+            response.put("data", Collections.emptyList());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+
         } catch (Exception e) {
-            e.printStackTrace();
-            return ResponseEntity.internalServerError().body(Collections.emptyList());
+            response.put("code", 500);
+            response.put("message", "동기화 실패: " + e.getMessage());
+            response.put("data", type);
+
+            return ResponseEntity.internalServerError().body(response);
         }
     }
 }

--- a/src/main/java/pepperstone/backend/sync/deprecated/controller/GoogleController.java
+++ b/src/main/java/pepperstone/backend/sync/deprecated/controller/GoogleController.java
@@ -1,10 +1,10 @@
-package pepperstone.backend.googlesheet.controller;
+package pepperstone.backend.sync.deprecated.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pepperstone.backend.googlesheet.service.GoogleService;
+import pepperstone.backend.sync.deprecated.service.GoogleService;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/pepperstone/backend/sync/deprecated/service/GoogleService.java
+++ b/src/main/java/pepperstone/backend/sync/deprecated/service/GoogleService.java
@@ -1,4 +1,4 @@
-package pepperstone.backend.googlesheet.service;
+package pepperstone.backend.sync.deprecated.service;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.JsonFactory;

--- a/src/main/java/pepperstone/backend/sync/service/EvaluationSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/EvaluationSyncService.java
@@ -1,0 +1,10 @@
+package pepperstone.backend.sync.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EvaluationSyncService {
+    private final SyncService syncService;
+}

--- a/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
@@ -1,0 +1,50 @@
+package pepperstone.backend.sync.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class JobSyncService {
+    private final SyncService syncService;
+
+    public List<Map<String, Object>> sync(String spreadsheetId) {
+        // 결과 데이터를 저장할 리스트 초기화
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        try {
+            // Google Sheet에서 데이터를 읽어옴
+            List<List<Object>> data = syncService.readSheet(spreadsheetId, "'참고. 직무별 퀘스트'!A1:Z100");
+
+            // 데이터가 비어 있거나 null이면 빈 리스트 반환
+            if (data == null || data.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            // Max, Medium 점수, 소속 센터, 직무 그룹, 주기 체크
+            List<Object> row11 = data.get(10);
+            System.out.println(row11);
+            Map<String, Object> row11map = new HashMap<>();
+            row11map.put("MaxScore",row11.get(1).toString().trim()); // Max 점수
+            row11map.put("MediumScore",row11.get(2).toString().trim()); // Medium 점수
+            row11map.put("CenterName", row11.get(5).toString().trim()); // 소속 센터
+            row11map.put("jobName", row11.get(6).toString().trim()); // 직무 그룹
+            // 주기 체크 [WEEKLY, MONTHLY]
+            if (row11.get(7).toString().trim().equals("주")){
+                row11map.put("period", "WEEKLY");
+            } else if (row11.get(7).toString().trim().equals("월")) {
+                row11map.put("period", "MONTHLY");
+            }
+
+            result.add(row11map);
+
+            // 결과 리스트 반환
+            return result;
+        } catch (Exception e) {
+            // 예외 발생 시 런타임 예외로 던지기
+            throw new RuntimeException("Error during job quest sync: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
@@ -1,50 +1,110 @@
+// JobSyncService.java
 package pepperstone.backend.sync.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pepperstone.backend.common.entity.*;
+import pepperstone.backend.common.entity.enums.Period;
+import pepperstone.backend.common.repository.*;
 
+import java.time.LocalDate;
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class JobSyncService {
+
     private final SyncService syncService;
+    private final JobQuestRepository jobQuestRepository;
+    private final JobQuestProgressRepository jobQuestProgressRepository;
+    private final UserRepository userRepository;
 
-    public List<Map<String, Object>> sync(String spreadsheetId) {
-        // 결과 데이터를 저장할 리스트 초기화
-        List<Map<String, Object>> result = new ArrayList<>();
+    private static final String RANGE = "'참고. 직무별 퀘스트'!A1:Z100";
 
-        try {
-            // Google Sheet에서 데이터를 읽어옴
-            List<List<Object>> data = syncService.readSheet(spreadsheetId, "'참고. 직무별 퀘스트'!A1:Z100");
+    @Transactional
+    public void sync(String spreadsheetId) {
+        List<List<Object>> data = syncService.readSheet(spreadsheetId, RANGE);
 
-            // 데이터가 비어 있거나 null이면 빈 리스트 반환
-            if (data == null || data.isEmpty()) {
-                return Collections.emptyList();
-            }
-
-            // Max, Medium 점수, 소속 센터, 직무 그룹, 주기 체크
-            List<Object> row11 = data.get(10);
-            System.out.println(row11);
-            Map<String, Object> row11map = new HashMap<>();
-            row11map.put("MaxScore",row11.get(1).toString().trim()); // Max 점수
-            row11map.put("MediumScore",row11.get(2).toString().trim()); // Medium 점수
-            row11map.put("CenterName", row11.get(5).toString().trim()); // 소속 센터
-            row11map.put("jobName", row11.get(6).toString().trim()); // 직무 그룹
-            // 주기 체크 [WEEKLY, MONTHLY]
-            if (row11.get(7).toString().trim().equals("주")){
-                row11map.put("period", "WEEKLY");
-            } else if (row11.get(7).toString().trim().equals("월")) {
-                row11map.put("period", "MONTHLY");
-            }
-
-            result.add(row11map);
-
-            // 결과 리스트 반환
-            return result;
-        } catch (Exception e) {
-            // 예외 발생 시 런타임 예외로 던지기
-            throw new RuntimeException("Error during job quest sync: " + e.getMessage(), e);
+        if (data == null || data.size() <= 10) {
+            throw new RuntimeException("Insufficient data in the spreadsheet.");
         }
+
+        List<Object> row = data.get(10);
+        String department = row.get(5).toString().trim();
+        String jobGroup = row.get(6).toString().trim();
+        String periodStr = row.get(7).toString().trim();
+        int maxScore = parseInteger(row, 1);
+        int mediumScore = parseInteger(row, 2);
+        double maxStandard = parseDouble(data.get(13), 5);
+        double mediumStandard = parseDouble(data.get(13), 6);
+        Period period = periodStr.equals("주") ? Period.WEEKLY : Period.MONTHLY;
+
+        // JobQuestsEntity 동기화 -> 조회 후, 없다면 생성o / 있다면 생성x
+        JobQuestsEntity jobQuest = jobQuestRepository.findByDepartmentAndJobGroup(department, jobGroup)
+                .orElseGet(() -> {
+                    JobQuestsEntity newJobQuest = new JobQuestsEntity();
+                    newJobQuest.setDepartment(department);
+                    newJobQuest.setJobGroup(jobGroup);
+                    newJobQuest.setPeriod(period);
+                    newJobQuest.setMaxScore(maxScore);
+                    newJobQuest.setMediumScore(mediumScore);
+                    newJobQuest.setMaxStandard(maxStandard);
+                    newJobQuest.setMediumStandard(mediumStandard);
+                    return jobQuestRepository.save(newJobQuest);
+                });
+
+        // 해당 직무 그룹과 센터 그룹에 속한 유저 조회
+        List<UserEntity> users = userRepository.findByJobGroupJobNameAndJobGroupCenterGroupCenterName(jobGroup, department);
+
+/*        for (UserEntity user : users) {
+            System.out.println("User ID: " + user.getId() + ", Name: " + user.getName());
+        }*/
+/*        for (UserEntity user : users) {
+            Optional<JobQuestProgressEntity> existingProgress = jobQuestProgressRepository.findByJobQuestId(jobQuest.getId())
+                    .stream()
+                    .filter(progress -> progress.getUsers().getId().equals(user.getId()) && progress.getWeek() == getCurrentWeek())
+                    .findFirst();
+
+            if (existingProgress.isEmpty()) {
+                // 새로운 JobQuestProgress 생성
+                JobQuestProgressEntity progress = new JobQuestProgressEntity();
+                progress.setJobQuest(jobQuest);
+                progress.setUsers(user);
+                progress.setWeek(getCurrentWeek());
+                progress.setCreatedAt(LocalDate.now());
+                progress.setProductivity(0.0);
+                progress.setExperience(0);
+                progress.setAccumulatedExperience(user.getAccumulatedExperience());
+                jobQuestProgressRepository.save(progress);
+            } else {
+                // 기존 JobQuestProgress 업데이트
+                JobQuestProgressEntity progress = existingProgress.get();
+                progress.setProductivity(0.0); // 생산성 초기화
+                progress.setExperience(0);     // 경험치 초기화
+                progress.setAccumulatedExperience(user.getAccumulatedExperience());
+                jobQuestProgressRepository.save(progress);
+            }
+        }*/
+    }
+
+    private int parseInteger(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private double parseDouble(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Double.parseDouble(row.get(index).toString().trim()) : 0.0;
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+
+    private int getCurrentWeek() {
+        return LocalDate.now().getDayOfYear() / 7 + 1;
     }
 }

--- a/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
@@ -58,9 +58,6 @@ public class JobSyncService {
         // 해당 직무 그룹과 센터 그룹에 속한 유저 조회
         List<UserEntity> users = userRepository.findByJobGroupJobNameAndJobGroupCenterGroupCenterName(jobGroup, department);
 
-/*        for (UserEntity user : users) {
-            System.out.println("User ID: " + user.getId() + ", Name: " + user.getName());
-        }*/
         for (UserEntity user : users) {
             // jobQuest와 user로 jobQuestProgress를 조회
             List<JobQuestProgressEntity> progressList = jobQuestProgressRepository.findByJobQuestAndUsers(jobQuest, user);

--- a/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
@@ -1,0 +1,10 @@
+package pepperstone.backend.sync.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeaderSyncService {
+    private final SyncService syncService;
+}

--- a/src/main/java/pepperstone/backend/sync/service/ProjectSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/ProjectSyncService.java
@@ -1,0 +1,10 @@
+package pepperstone.backend.sync.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectSyncService {
+    private final SyncService syncService;
+}

--- a/src/main/java/pepperstone/backend/sync/service/SyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/SyncService.java
@@ -1,0 +1,49 @@
+package pepperstone.backend.sync.service;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.*;
+
+@Service
+public class SyncService {
+    private static final String APPLICATION_NAME = "My First Project"; // Google Sheets 애플리케이션의 이름을 나타냄
+    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance(); // 상수는 JSON 데이터를 처리하기 위한 JsonFactory 인스턴스를 제공
+    private static final String CREDENTIALS_FILE_PATH = "/googlesheet/google.json"; // 인증에 사용되는 JSON 파링릐 경로를 지정
+    private Sheets sheetsService;
+
+    public List<List<Object>> readSheet(String spreadsheetId, String range) {
+        try {
+            Sheets service = getSheetsService();
+            ValueRange response = service.spreadsheets().values()
+                    .get(spreadsheetId, range)
+                    .execute();
+            List<List<Object>> values = response.getValues();
+            return values != null ? values : Collections.emptyList();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read data from the spreadsheet: " + e.getMessage(), e);
+        }
+    }
+
+    // 현재의 메소드는 Sheets 인스턴스를 얻는 데 사용
+    private Sheets getSheetsService() throws IOException, GeneralSecurityException {
+        if (sheetsService == null) {
+            GoogleCredentials credentials = GoogleCredentials.fromStream(new ClassPathResource(CREDENTIALS_FILE_PATH).getInputStream())
+                    // Google API를 호출할 떄 필요한 권한을 지정하는 부분 , 읽기/쓰기 권한을 나타냄
+                    .createScoped(Collections.singletonList("https://www.googleapis.com/auth/spreadsheets"));
+            sheetsService = new Sheets.Builder(GoogleNetHttpTransport.newTrustedTransport(), JSON_FACTORY, new HttpCredentialsAdapter(credentials))
+                    .setApplicationName(APPLICATION_NAME)
+                    .build();
+        }
+        return sheetsService;
+    }
+}


### PR DESCRIPTION
- 직무별 퀘스트 동기화(job)
    - “참고, 직무별 퀘스트” 시트 동기화
        - **동기화 항목**:
            - `jobQuests` 테이블
            - `jobQuestProgress` 테이블
            - `users` 테이블
        - **동기화 과정**:
            1. DB의 `centerGroup` 테이블의 `centerName`과 `jobGroup` 테이블의 `jobName`이 구글 스프레드 시트의 센터 그룹명, 직무 그룹명과 일치하는 유저들을 조회.
            2. 해당 유저들에게 직무 퀘스트를 부여하며 스프레드 시트에서 제공한 경험치를 동기화.
            3. 유저의 기존 진행 상황이 없을 경우, 새로운 `jobQuestProgress` 항목을 생성하고 1주차부터 시작.
            4. 유저의 기존 진행 상황이 있을 경우, 최신 주차의 데이터를 조회하여 다음 주차 데이터로 동기화.

close #5 