### PR TITLE
feat: 구글 스프레드 시트 동기화 - 리더부여 퀘스트

### DIFF
--- a/src/main/java/pepperstone/backend/common/repository/LeaderQuestProgressRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/LeaderQuestProgressRepository.java
@@ -1,0 +1,18 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.LeaderQuestProgressEntity;
+import pepperstone.backend.common.entity.LeaderQuestsEntity;
+import pepperstone.backend.common.entity.UserEntity;
+
+import java.util.Optional;
+
+@Repository
+public interface LeaderQuestProgressRepository extends JpaRepository<LeaderQuestProgressEntity, Long> {
+    Optional<LeaderQuestProgressEntity> findByLeaderQuestsAndUsersAndWeek(LeaderQuestsEntity leaderQuests, UserEntity user, int week);
+    Optional<LeaderQuestProgressEntity> findByLeaderQuestsAndUsersAndMonth(LeaderQuestsEntity leaderQuests, UserEntity user, int month);
+    Optional<LeaderQuestProgressEntity> findTopByLeaderQuestsAndUsersOrderByWeekDesc(LeaderQuestsEntity leaderQuest, UserEntity user);
+    Optional<LeaderQuestProgressEntity> findTopByLeaderQuestsAndUsersOrderByMonthDesc(LeaderQuestsEntity leaderQuest, UserEntity user);
+
+}

--- a/src/main/java/pepperstone/backend/common/repository/LeaderQuestRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/LeaderQuestRepository.java
@@ -1,0 +1,12 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.LeaderQuestsEntity;
+
+import java.util.Optional;
+
+@Repository
+public interface LeaderQuestRepository extends JpaRepository<LeaderQuestsEntity, Long> {
+    Optional<LeaderQuestsEntity> findByDepartmentAndJobGroupAndQuestName(String department, String jobGroup, String questName);
+}

--- a/src/main/java/pepperstone/backend/common/repository/UserRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/UserRepository.java
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Repository;
 import pepperstone.backend.common.entity.UserEntity;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     List<UserEntity> findByJobGroupJobNameAndJobGroupCenterGroupCenterName(String jobName, String centerName);
+    Optional<UserEntity> findByCompanyNumAndName(String companyNum, String name);
 }

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -30,7 +30,7 @@ public class SyncController {
             switch (type) {
                 case "all" -> {
                     jobSyncService.sync(SPREADSHEET_ID);
-                    //leaderSyncService.sync(SPREADSHEET_ID);
+                    leaderSyncService.sync(SPREADSHEET_ID);
                     //projectSyncService.sync(SPREADSHEET_ID);
                     //evaluationSyncService.sync(SPREADSHEET_ID);
                     message = "전체 동기화가 완료되었습니다.";
@@ -40,7 +40,7 @@ public class SyncController {
                     message = "직무별 퀘스트 동기화가 완료되었습니다.";
                 }
                 case "leader" -> {
-                    //leaderSyncService.sync(SPREADSHEET_ID);
+                    leaderSyncService.sync(SPREADSHEET_ID);
                     message = "리더부여 퀘스트 동기화가 완료되었습니다.";
                 }
                 case "project" -> {

--- a/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
@@ -114,8 +114,4 @@ public class JobSyncService {
             return 0.0;
         }
     }
-
-    private int getCurrentWeek() {
-        return LocalDate.now().getDayOfYear() / 7 + 1;
-    }
 }

--- a/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
@@ -37,20 +37,45 @@ public class LeaderSyncService {
         List<Map<String, Object>> peopleList = new ArrayList<>();
         peopleList = peopleList(data);
 
-        System.out.println("사원 정보:");
-        for (Map<String, Object> quest : peopleList) {
-            System.out.println(quest);
-        }
-
         // 퀘스트 정보를 저장할 리스트
         List<Map<String, Object>> questList = new ArrayList<>();
         questList = questList(data);
 
-        System.out.println("퀘스트 정보:");
-        for (Map<String, Object> quest : questList) {
-            System.out.println(quest);
-        }
+        // 퀘스트 달성 정보 저장 리스트
+        List<Map<String, Object>> questProgressList = new ArrayList<>();
+        questProgressList = questProgressList(data);
 
+
+
+/*        // 퀘스트 달성 정보 저장
+        for (Map<String, Object> person : peopleList) {
+            String personCompanyNum = person.get("companyNum").toString();
+
+            // 해당 사원의 퀘스트 달성 정보 필터링
+            List<Map<String, Object>> personAchievements = questProgressList.stream()
+                    .filter(quest -> quest.get("companyNum").equals(personCompanyNum))
+                    .toList();
+
+            if (personAchievements.isEmpty()) continue;
+
+            // 출력: 해당 사원에 대한 퀘스트 달성 정보
+            System.out.println("사원 정보:");
+            System.out.println("사번: " + personCompanyNum + ", 이름: " + person.get("name"));
+
+            for (Map<String, Object> achievement : personAchievements) {
+                String monthOrWeek = achievement.get("monthOrWeek").toString();
+                String questName = achievement.get("questName").toString();
+                String achievementType = achievement.get("achievementType").toString();
+                int experience = (int) achievement.get("experience");
+
+                // 출력: 퀘스트 달성 정보
+                System.out.println("  월/주: " + monthOrWeek);
+                System.out.println("  퀘스트명: " + questName);
+                System.out.println("  달성 유형: " + achievementType);
+                System.out.println("  부여 경험치: " + experience);
+                System.out.println("---------------------------");
+            }
+        }*/
 
     }
 
@@ -130,5 +155,40 @@ public class LeaderSyncService {
         }
 
         return questList;
+    }
+
+    // 퀘스트 달성 정보 저장 리스트 반환 메서드
+    private List<Map<String, Object>> questProgressList(List<List<Object>> data){
+        // 퀘스트 달성 정보 저장 리스트
+        List<Map<String, Object>> questProgressList = new ArrayList<>();
+
+        // 10번째 행부터 시작
+        int startRow = 9;
+        while (startRow < data.size() && data.get(startRow).size() > 5) {
+            List<Object> questRow = data.get(startRow);
+
+            // 필요한 정보 추출
+            int monthOrWeek = parseInteger(questRow, 1); // 월 또는 주 정보
+            String companyNum = questRow.get(2).toString().trim(); // 사번
+            String name = questRow.get(3).toString().trim(); // 이름
+            String questName = questRow.get(4).toString().trim(); // 퀘스트명
+            String achievementType = questRow.get(5).toString().trim(); // 달성내용 (Max, Median 등)
+            int experience = parseInteger(questRow, 6); // 부여 경험치
+
+            // 정보 저장
+            Map<String, Object> questInfo = new HashMap<>();
+            questInfo.put("companyNum", companyNum);
+            questInfo.put("name", name);
+            questInfo.put("questName", questName);
+            questInfo.put("achievementType", achievementType);
+            questInfo.put("experience", experience);
+            questInfo.put("monthOrWeek", monthOrWeek);
+
+            // 리스트에 추가
+            questProgressList.add(questInfo);
+
+            startRow++;
+        }
+        return questProgressList;
     }
 }

--- a/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
@@ -2,9 +2,88 @@ package pepperstone.backend.sync.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pepperstone.backend.common.entity.JobQuestProgressEntity;
+import pepperstone.backend.common.entity.JobQuestsEntity;
+import pepperstone.backend.common.entity.UserEntity;
+import pepperstone.backend.common.entity.enums.Period;
+import pepperstone.backend.common.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class LeaderSyncService {
     private final SyncService syncService;
+
+    private final UserRepository userRepository;
+
+    private static final String RANGE = "'참고. 리더부여 퀘스트'!A1:Z100";
+
+    @Transactional
+    public void sync(String spreadsheetId) {
+        List<List<Object>> data = syncService.readSheet(spreadsheetId, RANGE);
+
+        if (data == null || data.size() <= 10) {
+            throw new RuntimeException("Insufficient data in the spreadsheet.");
+        }
+
+        String department = data.get(18).get(12).toString().trim(); // 소속 센터
+        String jobGroup = data.get(18).get(13).toString().trim(); // 소속 그룹
+
+        // 퀘스트 정보를 저장할 리스트
+        List<Map<String, Object>> questList = new ArrayList<>();
+
+        // 11번째 행에서 정보 읽기
+        int startRow = 10;
+        // 퀘스트명이 빈칸이면 종료 || "합산"이 나오면 종료
+        while(!data.get(startRow).get(9).toString().isEmpty() && !data.get(startRow).get(9).toString().trim().equals("합산")) {
+            List<Object> questRow = data.get(startRow);
+
+            // 퀘스트 정보
+            String questName = questRow.get(9).toString().trim(); // 퀘스트명
+            String periodStr = questRow.get(10).toString().trim(); // 주기
+            String weightStr = questRow.get(11).toString().replace("%", "").trim(); // 불러온 비중에서 % 제거
+            int weight = Integer.parseInt(weightStr); // 비중
+            int maxPoints = parseInteger(questRow, 13); // max 점수
+            int medianPoints = parseInteger(questRow, 14); // medium 점수
+            String maxCondition = questRow.get(15).toString().trim(); // max 조건
+            String medianCondition = questRow.get(16).toString().trim(); // medium 조건
+            Period period = periodStr.equals("주") ? Period.WEEKLY : Period.MONTHLY;
+
+            // 퀘스트 정보를 맵으로 저장
+            Map<String, Object> questInfo = new HashMap<>();
+            questInfo.put("questName", questName);
+            questInfo.put("period", period);
+            questInfo.put("weight", weight);
+            questInfo.put("maxPoints", maxPoints);
+            questInfo.put("medianPoints", medianPoints);
+            questInfo.put("maxCondition", maxCondition);
+            questInfo.put("medianCondition", medianCondition);
+
+            // 리스트에 퀘스트 정보 추가
+            questList.add(questInfo);
+
+            startRow++;
+        }
+
+
+    }
+
+    private int parseInteger(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    private double parseDouble(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Double.parseDouble(row.get(index).toString().trim()) : 0.0;
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
 }

--- a/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
@@ -32,6 +32,67 @@ public class LeaderSyncService {
         String department = data.get(18).get(12).toString().trim(); // 소속 센터
         String jobGroup = data.get(18).get(13).toString().trim(); // 소속 그룹
 
+        // 소속 인원 정보
+        // 퀘스트 정보를 저장할 리스트
+        List<Map<String, Object>> peopleList = new ArrayList<>();
+        peopleList = peopleList(data);
+
+        System.out.println("사원 정보:");
+        for (Map<String, Object> quest : peopleList) {
+            System.out.println(quest);
+        }
+
+        // 퀘스트 정보를 저장할 리스트
+        List<Map<String, Object>> questList = new ArrayList<>();
+        questList = questList(data);
+
+        System.out.println("퀘스트 정보:");
+        for (Map<String, Object> quest : questList) {
+            System.out.println(quest);
+        }
+
+
+    }
+
+    private int parseInteger(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    // 사원 정보를 저장한 리스트 반환 메서드
+    private List<Map<String, Object>> peopleList(List<List<Object>> data){
+        // 퀘스트 정보를 저장할 리스트
+        List<Map<String, Object>> peopleList = new ArrayList<>();
+
+        // 19번째 행에서 정보 읽기
+        int startRow = 18;
+        // 사번이 빈칸이면 종료
+        while(startRow < data.size() && data.get(startRow).size() > 9 && !data.get(startRow).get(9).toString().isEmpty()) {
+            List<Object> personRow = data.get(startRow);
+
+            // 사원 정보
+            String companyNum = personRow.get(9).toString().trim(); // 사번
+            String name = personRow.get(10).toString().trim(); // 이름
+
+            // 사원 정보를 맵으로 저장
+            Map<String, Object> peopleInfo = new HashMap<>();
+            peopleInfo.put("companyNum", companyNum);
+            peopleInfo.put("name", name);
+
+            // 리스트에 사원 정보 추가
+            peopleList.add(peopleInfo);
+
+            startRow++;
+        }
+
+        return peopleList;
+    }
+
+    // 퀘스트 정보를 저장한 리스트 반환 메서드
+    private List<Map<String, Object>> questList(List<List<Object>> data){
         // 퀘스트 정보를 저장할 리스트
         List<Map<String, Object>> questList = new ArrayList<>();
 
@@ -68,22 +129,6 @@ public class LeaderSyncService {
             startRow++;
         }
 
-
-    }
-
-    private int parseInteger(List<Object> row, int index) {
-        try {
-            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
-
-    private double parseDouble(List<Object> row, int index) {
-        try {
-            return row.size() > index && !row.get(index).toString().isEmpty() ? Double.parseDouble(row.get(index).toString().trim()) : 0.0;
-        } catch (NumberFormatException e) {
-            return 0.0;
-        }
+        return questList;
     }
 }


### PR DESCRIPTION
- **동기화 항목**
    - `leaderQuests` 테이블
    - `leaderQuestProgress` 테이블
    - `users` 테이블 동기화
- **동기화 과정**
    1. **스프레드시트 데이터 읽기**
        - **사원 정보(peopleList)**: 사번과 이름을 기준으로 각 사원 정보를 리스트에 저장.
        - **퀘스트 정보(questList)**: 퀘스트명, 주기(주별 또는 월별), 비중(%), 최대/중간 점수 및 조건을 리스트에 저장.
        - **퀘스트 달성 정보(questProgressList)**: 사원의 퀘스트 달성 내역(사번, 퀘스트명, 달성 유형, 경험치 등)을 리스트에 저장.
    2. **리더 퀘스트 동기화**
        - 각 사원에 대해 해당 사원의 소속 센터와 직무 그룹을 기준으로 DB에서 **`users`** 테이블의 유저를 조회.
        - 조회된 유저에 대해 해당 소속과 직무 그룹으로 DB에서 **`leaderQuests`** 테이블을 조회.
            - **해당 퀘스트가 존재하지 않을 경우**:
                - 새로운 리더 퀘스트를 생성하여 **`leaderQuests`** 테이블에 저장.
            - **이미 존재할 경우**:
                - 기존 리더 퀘스트를 사용하여 진행 상태를 동기화.
    3. **퀘스트 진행 상태(leaderQuestProgress) 동기화**
        - 스프레드시트에서 가져온 퀘스트 달성 정보를 기준으로, 해당 유저가 이전에 수행한 퀘스트 진행 내역을 DB의 **`leaderQuestProgress`** 테이블에서 조회.
        - 주기(주별 또는 월별)에 따라 **week** 또는 **month** 필드를 기준으로 기존에 저장된 진행 정보를 확인.
            - **기존 데이터가 없을 경우**:
                - 누적 경험치를 계산하여 새로운 진행 데이터를 생성 및 저장.
            - **기존 데이터가 있을 경우**:
                - 이미 동기화된 데이터이므로 추가 작업 없이 다음 데이터로 이동.
    4. **경험치 누적 처리**
        - 새로운 진행 데이터를 추가할 때, **가장 최근의 진행 데이터**에서 **`accumulatedExperience`**와 **`experience`** 값을 합산하여 누적 경험치를 설정.
        - 주별 진행일 경우 **week** 필드를, 월별 진행일 경우 **month** 필드를 설정하여 저장


close #9 