### PR TITLE
feat: 구글 스프레드 시트 동기화 - 전사 프로젝트

### DIFF
--- a/src/main/java/pepperstone/backend/common/repository/ProjectsRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/ProjectsRepository.java
@@ -1,0 +1,11 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.ProjectsEntity;
+import pepperstone.backend.common.entity.UserEntity;
+
+@Repository
+public interface ProjectsRepository extends JpaRepository<ProjectsEntity, Long> {
+    boolean existsByUsersAndProjectName(UserEntity users, String projectName);
+}

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -31,7 +31,7 @@ public class SyncController {
                 case "all" -> {
                     jobSyncService.sync(SPREADSHEET_ID);
                     leaderSyncService.sync(SPREADSHEET_ID);
-                    //projectSyncService.sync(SPREADSHEET_ID);
+                    projectSyncService.sync(SPREADSHEET_ID);
                     //evaluationSyncService.sync(SPREADSHEET_ID);
                     message = "전체 동기화가 완료되었습니다.";
                 }
@@ -44,7 +44,7 @@ public class SyncController {
                     message = "리더부여 퀘스트 동기화가 완료되었습니다.";
                 }
                 case "project" -> {
-                    //projectSyncService.sync(SPREADSHEET_ID);
+                    projectSyncService.sync(SPREADSHEET_ID);
                     message = "전사 프로젝트 동기화가 완료되었습니다.";
                 }
                 case "evaluation" -> {

--- a/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/JobSyncService.java
@@ -1,4 +1,3 @@
-// JobSyncService.java
 package pepperstone.backend.sync.service;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/LeaderSyncService.java
@@ -140,7 +140,7 @@ public class LeaderSyncService {
 
     // 사원 정보를 저장한 리스트 반환 메서드
     private List<Map<String, Object>> peopleList(List<List<Object>> data){
-        // 퀘스트 정보를 저장할 리스트
+        // 사원 정보를 저장할 리스트
         List<Map<String, Object>> peopleList = new ArrayList<>();
 
         // 19번째 행에서 정보 읽기

--- a/src/main/java/pepperstone/backend/sync/service/ProjectSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/ProjectSyncService.java
@@ -2,9 +2,103 @@ package pepperstone.backend.sync.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pepperstone.backend.common.entity.ProjectsEntity;
+import pepperstone.backend.common.entity.UserEntity;
+import pepperstone.backend.common.repository.ProjectsRepository;
+import pepperstone.backend.common.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class ProjectSyncService {
     private final SyncService syncService;
+    private final UserRepository userRepository;
+    private final ProjectsRepository projectsRepository;
+
+    private static final String RANGE = "'참고. 전사 프로젝트'!A1:Z100";
+
+    @Transactional
+    public void sync(String spreadsheetId) {
+        List<List<Object>> data = syncService.readSheet(spreadsheetId, RANGE);
+
+        if (data == null || data.size() <= 7) {
+            throw new RuntimeException("Insufficient data in the spreadsheet.");
+        }
+
+        // 전사 프로젝트 정보 가져오기(사번, 이름, 전사 프로젝트명, 부여경험치)
+        List<Map<String, Object>> projectList = projectList(data);
+
+        // 전사 프로젝트 동기화
+        for (Map<String, Object> projectInfo : projectList) {
+            String companyNum = projectInfo.get("companyNum").toString();
+            String name = projectInfo.get("name").toString();
+            String projectName = projectInfo.get("projectName").toString();
+            int experience = (int) projectInfo.get("experience");
+
+            // users 테이블에서 해당 사원 조회
+            UserEntity user = userRepository.findByCompanyNumAndName(companyNum, name)
+                    .orElseThrow(() -> new RuntimeException("User not found: " + companyNum + ", " + name));
+
+            // 이미 동일한 프로젝트가 저장되어 있는지 확인
+            boolean projectExists = projectsRepository.existsByUsersAndProjectName(user, projectName);
+            if (projectExists) {
+                System.out.println("이미 등록된 프로젝트입니다: " + projectName + " (" + companyNum + ")");
+                continue;
+            }
+
+            // 새로운 프로젝트 생성 및 저장
+            ProjectsEntity project = new ProjectsEntity();
+            project.setUsers(user);
+            project.setProjectName(projectName);
+            project.setExperience(experience);
+            project.setCreatedAt(LocalDate.now());
+
+            projectsRepository.save(project);
+        }
+
+    }
+
+    private int parseInteger(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    // 전사 프로젝트 정보를 저장한 리스트 반환 메서드
+    private List<Map<String, Object>> projectList(List<List<Object>> data){
+        // 전사 프로젝트 정보를 저장할 리스트
+        List<Map<String, Object>> projectList = new ArrayList<>();
+
+        // 8번째 행에서 정보 읽기
+        int startRow = 7;
+        // 사번이 빈칸이면 종료
+        while(startRow < data.size() && data.get(startRow).size() > 6 && !data.get(startRow).get(3).toString().isEmpty()) {
+            List<Object> projectRow = data.get(startRow);
+
+            // 프로젝트 사원 및 경험치 정보
+            String companyNum = projectRow.get(3).toString().trim(); // 사번
+            String name = projectRow.get(4).toString().trim(); // 이름
+            String projectName = projectRow.get(5).toString().trim(); // 전사 프로젝트명
+            int experience = parseInteger(projectRow, 6); // 부여 경험치
+
+            // 사원 정보를 맵으로 저장
+            Map<String, Object> peopleInfo = new HashMap<>();
+            peopleInfo.put("companyNum", companyNum);
+            peopleInfo.put("name", name);
+            peopleInfo.put("projectName", projectName);
+            peopleInfo.put("experience", experience);
+
+            // 리스트에 사원 정보 추가
+            projectList.add(peopleInfo);
+
+            startRow++;
+        }
+
+        return projectList;
+    }
 }


### PR DESCRIPTION
- **동기화 항목**
    - `projects` 테이블
    - `users` 테이블
- **동기화 과정**
    - **DB의 `users` 테이블과 비교**
        - 구글 스프레드 시트에서 불러온 사번(`companyNum`)과 DB의 `users` 테이블에 저장된 **사번**이 일치하는 유저를 조회
    - **프로젝트 존재 여부 확인**
        - 해당 유저에게 동일한 프로젝트명(`projectName`)이 이미 등록되어 있는지 `projects` 테이블에서 확인
        - 이미 등록된 경우 해당 프로젝트를 건너뛰고 다음 항목으로 진행
    - **새로운 프로젝트 생성**
        - 스프레드 시트에서 가져온 **프로젝트명**과 **부여된 경험치**를 기반으로 새로운 프로젝트를 생성하여 `projects` 테이블에 저장
        - 동기화 시점의 날짜를 부여 일자(`createdAt`)로 설정


close #13 