### PR TITLE
feat: 구글 스프레드 시트 동기화 - 인사평가

### DIFF
--- a/src/main/java/pepperstone/backend/common/repository/PerformanceEvaluationRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/PerformanceEvaluationRepository.java
@@ -1,0 +1,16 @@
+package pepperstone.backend.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pepperstone.backend.common.entity.PerformanceEvaluationEntity;
+import pepperstone.backend.common.entity.UserEntity;
+import pepperstone.backend.common.entity.enums.EvaluationPeriod;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface PerformanceEvaluationRepository extends JpaRepository<PerformanceEvaluationEntity, Long> {
+    // 특정 유저, 평가 기간, 연도에 해당하는 인사평가 데이터를 삭제하는 메서드
+    void deleteByUsersAndEvaluationPeriodAndCreatedAtBetween(UserEntity users, EvaluationPeriod evaluationPeriod, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/pepperstone/backend/sync/controller/SyncController.java
+++ b/src/main/java/pepperstone/backend/sync/controller/SyncController.java
@@ -32,7 +32,7 @@ public class SyncController {
                     jobSyncService.sync(SPREADSHEET_ID);
                     leaderSyncService.sync(SPREADSHEET_ID);
                     projectSyncService.sync(SPREADSHEET_ID);
-                    //evaluationSyncService.sync(SPREADSHEET_ID);
+                    evaluationSyncService.sync(SPREADSHEET_ID);
                     message = "전체 동기화가 완료되었습니다.";
                 }
                 case "job" -> {
@@ -48,7 +48,7 @@ public class SyncController {
                     message = "전사 프로젝트 동기화가 완료되었습니다.";
                 }
                 case "evaluation" -> {
-                    //evaluationSyncService.sync(SPREADSHEET_ID);
+                    evaluationSyncService.sync(SPREADSHEET_ID);
                     message = "인사 평가 동기화가 완료되었습니다.";
                 }
                 default -> throw new IllegalArgumentException("Invalid sync type: " + type);

--- a/src/main/java/pepperstone/backend/sync/service/EvaluationSyncService.java
+++ b/src/main/java/pepperstone/backend/sync/service/EvaluationSyncService.java
@@ -2,9 +2,107 @@ package pepperstone.backend.sync.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pepperstone.backend.common.entity.PerformanceEvaluationEntity;
+import pepperstone.backend.common.entity.UserEntity;
+import pepperstone.backend.common.entity.enums.EvaluationPeriod;
+import pepperstone.backend.common.entity.enums.Grade;
+import pepperstone.backend.common.repository.PerformanceEvaluationRepository;
+import pepperstone.backend.common.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class EvaluationSyncService {
     private final SyncService syncService;
+    private final UserRepository userRepository;
+    private final PerformanceEvaluationRepository performanceEvaluationRepository;
+
+    private static final String RANGE = "'참고. 인사평가'!A1:Z100";
+
+    @Transactional
+    public void sync(String spreadsheetId) {
+        List<List<Object>> data = syncService.readSheet(spreadsheetId, RANGE);
+
+        if (data == null || data.size() <= 9) {
+            throw new RuntimeException("Insufficient data in the spreadsheet.");
+        }
+
+        // 현재 날짜 기준으로 상반기 또는 하반기 결정
+        LocalDate today = LocalDate.now();
+        EvaluationPeriod evaluationPeriod = (today.getMonthValue() <= 6) ? EvaluationPeriod.H1 : EvaluationPeriod.H2;
+
+        // 인사평가 정보 가져오기
+        List<Map<String, Object>> evaluationList = evaluationList(data, evaluationPeriod);
+
+        // 인사평가 동기화
+        for (Map<String, Object> evaluationInfo : evaluationList) {
+            String companyNum = evaluationInfo.get("companyNum").toString();
+            String name = evaluationInfo.get("name").toString();
+            Grade grade = (Grade) evaluationInfo.get("grade");
+            int experience = (int) evaluationInfo.get("experience");
+
+            // users 테이블에서 해당 사원 조회
+            UserEntity user = userRepository.findByCompanyNumAndName(companyNum, name)
+                    .orElseThrow(() -> new RuntimeException("User not found: " + companyNum + ", " + name));
+
+            // 기존에 동일한 평가 기간과 연도에 대한 데이터가 있는 경우 삭제
+            LocalDate startOfPeriod = evaluationPeriod == EvaluationPeriod.H1 ? LocalDate.of(today.getYear(), 1, 1) : LocalDate.of(today.getYear(), 7, 1);
+            LocalDate endOfPeriod = evaluationPeriod == EvaluationPeriod.H1 ? LocalDate.of(today.getYear(), 6, 30) : LocalDate.of(today.getYear(), 12, 31);
+            performanceEvaluationRepository.deleteByUsersAndEvaluationPeriodAndCreatedAtBetween(user, evaluationPeriod, startOfPeriod, endOfPeriod);
+
+            // 새로운 인사평가 데이터 생성 및 저장
+            PerformanceEvaluationEntity evaluation = new PerformanceEvaluationEntity();
+            evaluation.setUsers(user);
+            evaluation.setEvaluationPeriod(evaluationPeriod);
+            evaluation.setGrade(grade);
+            evaluation.setExperience(experience);
+            evaluation.setCreatedAt(LocalDate.now());
+
+            performanceEvaluationRepository.save(evaluation);
+        }
+    }
+
+    private List<Map<String, Object>> evaluationList(List<List<Object>> data, EvaluationPeriod period) {
+        // 인사평가 정보를 저장할 리스트
+        List<Map<String, Object>> evaluationList = new ArrayList<>();
+
+        int startRow = 9; // 상반기: 10행, 하반기: 10행
+        int startCol = (period == EvaluationPeriod.H1) ? 1 : 7; // 상반기: 2열, 하반기: 8열
+
+        while (startRow < data.size() && data.get(startRow).size() > startCol && !data.get(startRow).get(startCol).toString().isEmpty()) {
+            List<Object> row = data.get(startRow);
+
+            // 인사평가 정보 파싱
+            String companyNum = row.get(startCol).toString().trim(); // 사번
+            String name = row.get(startCol + 1).toString().trim(); // 이름
+            Grade grade = Grade.valueOf(row.get(startCol + 2).toString().trim().substring(0, 1)); // 등급 (첫 글자)
+            int experience = parseInteger(row, startCol + 3); // 부여 경험치
+
+            // 정보를 맵에 저장
+            Map<String, Object> evaluationInfo = new HashMap<>();
+            evaluationInfo.put("companyNum", companyNum);
+            evaluationInfo.put("name", name);
+            evaluationInfo.put("grade", grade);
+            evaluationInfo.put("experience", experience);
+
+            evaluationList.add(evaluationInfo);
+            startRow++;
+        }
+
+        return evaluationList;
+    }
+
+    private int parseInteger(List<Object> row, int index) {
+        try {
+            return row.size() > index && !row.get(index).toString().isEmpty() ? Integer.parseInt(row.get(index).toString().trim()) : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
 }


### PR DESCRIPTION
- **동기화 항목**
    - `performanceEvaluation` 테이블
    - `users` 테이블
- **동기화 대상 및 범위**
    - **“참고, 인사평가”** 시트에 입력된 상/하반기 인사평가 데이터를 동기화
        - **상반기:** 1월 1일부터 6월 30일까지 입력된 데이터를 기준으로 동기화
        - **하반기:** 7월 1일부터 12월 31일까지 입력된 데이터를 기준으로 동기화
- **동기화 방식**
    - **performanceEvaluation 테이블**과 **users 테이블** 동기화
        - **DB의 users 테이블의 companyNum**(사번)과 **스프레드시트에서 불러온 사번**이 일치하는 유저를 기준으로 동기화 진행
        - 해당 유저에게 **상반기(H1)** 또는 **하반기(H2)**에 대한 인사평가 데이터를 동기화하고, **스프레드시트에서 가져온 경험치**를 부여
        - **기존 데이터 처리 방식:**
            - 동일한 유저와 동일한 평가 기간(상반기 또는 하반기) 내에 이미 저장된 인사평가 데이터가 있을 경우, 해당 데이터를 삭제하고 새 데이터를 삽입
            - 데이터 삭제 시, **연도(year)**와 **평가 기간(evaluationPeriod)**를 기준으로 구분하여 삭제 처리
        - 새로운 데이터는 **현재 날짜(LocalDate.now())**를 기준으로 작성


close #15 