### PR TITLE
feat: 홈화면 응답 데이터

### DIFF
--- a/src/main/java/pepperstone/backend/common/repository/UserRepository.java
+++ b/src/main/java/pepperstone/backend/common/repository/UserRepository.java
@@ -30,4 +30,5 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
                                          Pageable pageable);
 
     List<UserEntity> findByJobGroup_CenterGroup_CenterNameAndJobGroup_JobName(String centerGroup, String jobGroup);
+    List<UserEntity> findByJobGroupId(Long jobGroupId);
 }

--- a/src/main/java/pepperstone/backend/experience/controller/ExperienceController.java
+++ b/src/main/java/pepperstone/backend/experience/controller/ExperienceController.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 public class ExperienceController {
     private final ExperienceService experienceService;
     private final UserRepository userRepository;
+
     @GetMapping("/current")
     public ResponseEntity<Map<String, Object>> getCurrentExperience(@AuthenticationPrincipal UserEntity userInfo) {
         try {

--- a/src/main/java/pepperstone/backend/home/controller/HomeController.java
+++ b/src/main/java/pepperstone/backend/home/controller/HomeController.java
@@ -1,0 +1,42 @@
+package pepperstone.backend.home.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pepperstone.backend.common.entity.UserEntity;
+import pepperstone.backend.common.repository.UserRepository;
+import pepperstone.backend.home.service.HomeService;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    private final HomeService homeService;
+    private final UserRepository userRepository;
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> getHomeData(@AuthenticationPrincipal UserEntity userInfo) {
+        try {
+
+            Optional<UserEntity> user = userRepository.findById(userInfo.getId());
+
+            if (user.isEmpty()) {
+                return ResponseEntity.status(404).body(Map.of("code", 404, "message", "Not Found: 사용자 정보가 존재하지 않습니다."));
+            }
+            return ResponseEntity.ok(Map.of("code", 200, "data", homeService.getHomeData(user.get())));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(404).body(Map.of("code", 404, "data", e.getMessage()));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(500).body(Map.of("code", 500, "message", "Internal Server Error: 홈 화면 데이터를 가져오는 도중 오류가 발생했습니다."));
+        }
+    }
+}

--- a/src/main/java/pepperstone/backend/home/dto/response/HomeDto.java
+++ b/src/main/java/pepperstone/backend/home/dto/response/HomeDto.java
@@ -1,0 +1,40 @@
+package pepperstone.backend.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HomeDto {
+
+    private UserDto user;
+    private TeamDto team;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UserDto {
+        private String name;
+        private String level;
+        private String centerName;
+        private String jobName;
+        private int recentExperience;
+        private int totalExperienceThisYear;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class TeamDto {
+        private int count;
+        private List<String> levels;
+    }
+}

--- a/src/main/java/pepperstone/backend/home/service/HomeService.java
+++ b/src/main/java/pepperstone/backend/home/service/HomeService.java
@@ -1,0 +1,158 @@
+package pepperstone.backend.home.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pepperstone.backend.common.entity.*;
+import pepperstone.backend.common.repository.*;
+import pepperstone.backend.home.dto.response.HomeDto;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private final JobQuestProgressRepository jobQuestProgressRepository;
+    private final LeaderQuestProgressRepository leaderQuestProgressRepository;
+    private final ProjectsRepository projectsRepository;
+    private final PerformanceEvaluationRepository performanceEvaluationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public HomeDto getHomeData(UserEntity user) {
+        if (user == null) {
+            throw new IllegalArgumentException("Not Found: 데이터가 존재하지 않습니다.");
+        }
+
+        return HomeDto.builder()
+                .user(getUserData(user))
+                .team(getTeamData(user))
+                .build();
+    }
+
+    // ============== private methods ================
+
+    // 사용자 데이터를 생성하는 메서드
+    private HomeDto.UserDto getUserData(UserEntity user) {
+        // 최근 획득 경험치
+        int recentExperience = getRecentExperience(user);
+
+        // 올해의 시작일과 끝일
+        LocalDate startOfYear = LocalDate.of(LocalDate.now().getYear(), 1, 1);
+        LocalDate endOfYear = LocalDate.of(LocalDate.now().getYear(), 12, 31);
+
+        // 올해 획득한 총 경험치 합산
+        int totalExperienceThisYear = getLatestJobAndLeaderQuestExperience(user, startOfYear, endOfYear)
+                + getProjectExperience(user, startOfYear, endOfYear)
+                + getPerformanceEvaluationExperience(user, startOfYear, endOfYear);
+
+        return HomeDto.UserDto.builder()
+                .name(user.getName())
+                .level(user.getLevel())
+                .centerName(user.getJobGroup().getCenterGroup().getCenterName())
+                .jobName(user.getJobGroup().getJobName())
+                .recentExperience(recentExperience)
+                .totalExperienceThisYear(totalExperienceThisYear)
+                .build();
+    }
+
+    // 팀원 데이터를 생성하는 메서드
+    private HomeDto.TeamDto getTeamData(UserEntity user) {
+        List<UserEntity> teamMembers = userRepository.findByJobGroupId(user.getJobGroup().getId());
+        List<String> levels = teamMembers.stream()
+                .map(UserEntity::getLevel)
+                .collect(Collectors.toList());
+
+        return HomeDto.TeamDto.builder()
+                .count(teamMembers.size()) // 팀원 수
+                .levels(levels) // 팀원 레벨 리스트
+                .build();
+    }
+
+    // 최근 획득 경험치를 계산하는 메서드
+    private int getRecentExperience(UserEntity user) {
+        // 각 엔티티에서 (경험치, 날짜) 쌍을 추출
+        // 직무 퀘스트
+        Optional<Pair<Integer, LocalDate>> jobExperience = jobQuestProgressRepository.findByUsers(user).stream()
+                .max(Comparator.comparing(JobQuestProgressEntity::getCreatedAt)
+                        .thenComparing(JobQuestProgressEntity::getWeek, Comparator.reverseOrder()))
+                .map(jq -> Pair.of(jq.getExperience(), jq.getCreatedAt()));
+
+        // 리더부여 퀘스트
+        Optional<Pair<Integer, LocalDate>> leaderExperience = leaderQuestProgressRepository.findByUsers(user).stream()
+                .max(Comparator.comparing(LeaderQuestProgressEntity::getCreatedAt)
+                        .thenComparing(lq -> lq.getWeek() != null ? lq.getWeek() : lq.getMonth(), Comparator.reverseOrder()))
+                .map(lq -> Pair.of(lq.getExperience(), lq.getCreatedAt()));
+
+        // 전사 프로젝트
+        Optional<Pair<Integer, LocalDate>> projectExperience = projectsRepository.findByUsers(user).stream()
+                .max(Comparator.comparing(ProjectsEntity::getCreatedAt))
+                .map(p -> Pair.of(p.getExperience(), p.getCreatedAt()));
+
+        // 인사평가
+        Optional<Pair<Integer, LocalDate>> evaluationExperience = performanceEvaluationRepository.findByUsers(user).stream()
+                .max(Comparator.comparing(PerformanceEvaluationEntity::getCreatedAt))
+                .map(e -> Pair.of(e.getExperience(), e.getCreatedAt()));
+
+        // 4개의 Optional<Pair> 중 가장 최신 날짜의 경험치 선택
+        return Stream.of(jobExperience, leaderExperience, projectExperience, evaluationExperience)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .max(Comparator.comparing(Pair::getRight)) // 날짜 기준으로 최대값 찾기
+                .map(Pair::getLeft) // 경험치 값 반환
+                .orElse(0); // 데이터가 없으면 0 반환
+    }
+
+    // 직퀘, 리퀘에서 조건에 맞는 최신 데이터의 accumulatedExperience + experience 값을 반환
+    private int getLatestJobAndLeaderQuestExperience(UserEntity user, LocalDate startDate, LocalDate endDate) {
+        // JobQuestProgress에서 연도가 올해이고 week가 가장 높은 데이터 조회
+        Optional<JobQuestProgressEntity> latestJobQuest = jobQuestProgressRepository
+                .findByUsersAndCreatedAtBetween(user, startDate, endDate)
+                .stream()
+                .max(Comparator.comparing(JobQuestProgressEntity::getWeek));
+
+        // LeaderQuestProgress에서 leader_quest_id별로 연도가 올해이고 week나 month가 가장 큰 데이터 조회
+        List<LeaderQuestProgressEntity> leaderQuestProgressList = leaderQuestProgressRepository
+                .findByUsersAndCreatedAtBetween(user, startDate, endDate);
+
+        // leader_quest_id별로 최신 데이터를 선택하여 누적 경험치 합산
+        int leaderQuestExperience = leaderQuestProgressList.stream()
+                .collect(Collectors.groupingBy(lq -> lq.getLeaderQuests().getId(), // leader_quest_id 기준으로 그룹화
+                        Collectors.maxBy(Comparator.comparing(lq -> lq.getWeek() != null ? lq.getWeek() : lq.getMonth())))) // week 또는 month 기준으로 최신 데이터 선택
+                .values().stream()
+                .filter(Optional::isPresent) // Optional 필터링
+                .mapToInt(optLq -> {
+                    LeaderQuestProgressEntity lq = optLq.get();
+                    return lq.getAccumulatedExperience() + lq.getExperience();
+                })
+                .sum();
+
+        // 가장 최신 데이터 중 하나를 선택하여 경험치 계산
+        int jobQuestExperience = latestJobQuest.map(jq -> jq.getAccumulatedExperience() + jq.getExperience()).orElse(0);
+
+        return jobQuestExperience + leaderQuestExperience;
+    }
+
+    private int getProjectExperience(UserEntity user, LocalDate startDate, LocalDate endDate) {
+        return projectsRepository.findByUsersAndCreatedAtBetween(user, startDate, endDate)
+                .stream()
+                .mapToInt(ProjectsEntity::getExperience)
+                .sum();
+    }
+
+    private int getPerformanceEvaluationExperience(UserEntity user, LocalDate startDate, LocalDate endDate) {
+        return performanceEvaluationRepository.findByUsersAndCreatedAtBetween(user, startDate, endDate)
+                .stream()
+                .mapToInt(PerformanceEvaluationEntity::getExperience)
+                .sum();
+    }
+}


### PR DESCRIPTION
- **본인 데이터**
    - 유저 이름(name),
    - 나의 레벨(level),
    - 소속 센터(centerName),
    - 소속 직무 그룹(jobName),
    - 최근 획득 경험치(jobQuestProgress, leaderQuestProgress, projects, performanceEvaluation 테이블에서 createAt을 기준으로 가장 최근의 experience → jobQuestProgress는 createAt이 같다면 week 내림차순 중 가장 높은 것,  leaderQuestProgress는 createAt이 같다면 week 혹은 month 값에 대해 내림차순으로 정렬 후 가장 높은 것)
    - 올해 획득한 총 경험치(jobQuestProgress의 accumulatedExperience, leaderQuestProgress의 accumulatedExperience, projects의 accumulatedExperience, performanceEvaluation 테이블의 본인 userId에 해당하는 테이블의 모든 experience 합산 ⇒ 이 4종류의 경험치의 총 합산)
        - JobQuestProgressEntity에서는 연도는 올해이며 week가 가장 높은 숫자인것의 accumulatedExperience + experience를 구하고, LeaderQuestProgressEntity에서는 연도는 올해이며 leader_quest_id마다 week나 month(LeaderQuest 테이블에 period가 정해져있음 예시.week면 month는 null, month면 week가 null)의 값이 가장 큰 데이터의 accumulatedExperience + experience를 구한다.
- **팀원 데이터**
    - 소속 직무 그룹의 팀원들의 수
    - 팀원 레벨 리스트(jobGroup의 동일한 id를 보유한 user들의 level 리스트)


close #44 