### PR TITLE
feat: 도전과제 아이템 해금 로직 추가

### DIFF
--- a/src/main/java/pepperstone/backend/challenge/service/ChallengeService.java
+++ b/src/main/java/pepperstone/backend/challenge/service/ChallengeService.java
@@ -9,10 +9,13 @@ import pepperstone.backend.challenge.dto.response.ChallengeReceiveDto;
 import pepperstone.backend.challenge.dto.response.ChallengeDto;
 import pepperstone.backend.common.entity.ChallengeProgressEntity;
 import pepperstone.backend.common.entity.ChallengesEntity;
+import pepperstone.backend.common.entity.UnlockStatusEntity;
 import pepperstone.backend.common.entity.UserEntity;
 import pepperstone.backend.common.entity.enums.ChallengeType;
+import pepperstone.backend.common.entity.enums.ItemType;
 import pepperstone.backend.common.repository.ChallengeProgressRepository;
 import pepperstone.backend.common.repository.ChallengesRepository;
+import pepperstone.backend.common.repository.UnlockStatusRepository;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,7 +27,9 @@ public class ChallengeService {
 
     private final ChallengeProgressRepository challengeProgressRepository;
     private final ChallengesRepository challengesRepository;
+    private final UnlockStatusRepository unlockStatusRepository;
 
+    // 도전과제 달성 아이템 수령 메서드
     @Transactional
     public ChallengeReceiveDto receiveReward(UserEntity user, Long challengeProgressId) {
         // 도전 과제 진행 상황 조회
@@ -40,6 +45,19 @@ public class ChallengeService {
         progress.setReceive(true);
         challengeProgressRepository.save(progress);
 
+        // 아이템 부여 로직 추가
+        ChallengesEntity challenge = progress.getChallenges();
+        String itemValue = getItemForChallenge(challenge.getType()); // 과제별 아이템 값 가져오기
+        if (itemValue != null) {
+            UnlockStatusEntity unlockStatus = UnlockStatusEntity.builder()
+                    .itemType(ItemType.SKIN) // 모든 과제에 대해 SKIN 타입 아이템 부여
+                    .itemValue(itemValue)
+                    .users(user)
+                    .build();
+            unlockStatusRepository.save(unlockStatus);
+            log.info("아이템 해금: 사용자={}, 아이템 타입={}, 아이템 값={}", user.getName(), ItemType.SKIN, itemValue);
+        }
+
         // DTO에 응답 데이터 세팅 후 반환
         return ChallengeReceiveDto.builder()
                 .challengeProgressId(progress.getId())
@@ -47,6 +65,7 @@ public class ChallengeService {
                 .build();
     }
 
+    // 도전과제 리스트 반환 메서드
     public List<ChallengeDto> getChallengeList(UserEntity user) {
         // 모든 도전 과제 유형에 대해 진행 상황을 조회하고 없으면 초기값으로 생성
         for (ChallengeType type : ChallengeType.values()) {
@@ -92,6 +111,17 @@ public class ChallengeService {
                     newProgress.setReceive(false);
                     return challengeProgressRepository.save(newProgress);
                 });
+    }
+
+    // 과제별 아이템 값 매핑 메서드
+    private String getItemForChallenge(ChallengeType type) {
+        return switch (type) {
+            case BOARD_READ -> "S1";
+            case JOB_QUEST_MAX -> "S2";
+            case LEADER_QUEST_MAX -> "S3";
+            case PROJECT_PARTICIPATION -> "S4";
+            case PERFORMANCE_A -> "S5";
+        };
     }
 
     // 엔티티를 ChallengeResponseDTO로 변환하는 메서드


### PR DESCRIPTION
도전과제를 완료하여 아이템 받기 버튼을 누르면 아이템 수령 여부 체크 로직

1. challengeProgress_id를 전달해주면
2. receive를 false에서 true로 patch한다
3. 도전과제 달성 시 아이템 추가 → 아이템 받기 버튼 클리시: /challenge/receive 요청에서 해당 과제에 맞는 아이템을 부여
    - 해당 과제에 맞는 아이템을 부여
        - 과제1: S1 / 과제2: S2 / 과제3: S3 / 과제4: S4 / 과제5: S5
        - 아이템 해금은 unlockStatus 테이블에 부여하고자 하는 아이템 타입(enumg형 itemType: [SKIN, DECORATION, EFFECT] 중 SKIN )과 아이템 값(itemValue: 예: "S1")을 저장
            - 예시
                - itemType: SKIN
                - itemValue: S1
        - 과제1: 게시글 5개 확인 / 과제2: 직무별 퀘스트 MAX기준 10회 달성 / 과제3: 리더부여 퀘스트 MAX기준 10회 달성 / 과제4: 전사프로젝트를 1회 참여 / 과제5: 인사평가에서 A 등급 달성

close #46 